### PR TITLE
Fix query detail

### DIFF
--- a/app/models/database.py
+++ b/app/models/database.py
@@ -50,17 +50,7 @@ class Database:
             else:
                 logging.critical(f"Database {self.storage_type} not supported (only SQLite & PostgresSQL)")
 
-        # Use alembic commands rather than dropping into shell for running migrations
-        alembic_dir = os.path.join(APPLICATION_PATH, "alembic")
-        alembic_ini = os.path.join(APPLICATION_PATH, "alembic.ini")
-        alembic_cfg = AlembicConfig(alembic_ini)
-        alembic_cfg.set_main_option('script_location', alembic_dir)
-
-        # Define DB_URL envvar rather than using set_main_option so that command line
-        # migrations are still possible
-        os.environ["DB_URL"] = self.uri
-
-        command.upgrade(alembic_cfg, "head")
+        os.system(f"cd {APPLICATION_PATH}; DB_URL='{self.uri}' alembic upgrade head ")
 
         self.engine = create_engine(
             self.uri, echo=False,

--- a/app/models/query_detail.py
+++ b/app/models/query_detail.py
@@ -124,7 +124,7 @@ class Detail:
                             date_object = datetime.strptime(date, self.date_detail_format)
                             # CHANGE DATE TO BEGIN RANGE
                             date = date_object - timedelta(minutes=int(interval))
-                            date = date.strftime(self.date_detail_format)
+                            # date = date.strftime(self.date_detail_format)
                             # GET WEEKDAY
                             # date_days = date_object.weekday()
                             # date_hour_minute = date_object.strftime('%H:%M')


### PR DESCRIPTION
### Motivation
Ensure master is safe to run

### Changes
- master was not able to produce a properly running docker image due to `# date = date.strftime(self.date_detail_format)`
- using alembic command messed up the logging